### PR TITLE
Replace deprecated uses of callback with caml_callback

### DIFF
--- a/src/implem/canvas.c
+++ b/src/implem/canvas.c
@@ -226,9 +226,9 @@ static void (*_canvas_destroy_callback)(canvas_t *) = NULL;
 
 void
 canvas_set_destroy_callback(
-  void (*callback)(canvas_t *))
+  void (*callback_function)(canvas_t *))
 {
-  _canvas_destroy_callback = callback;
+  _canvas_destroy_callback = callback_function;
 }
 
 static void

--- a/src/implem/canvas.h
+++ b/src/implem/canvas.h
@@ -67,7 +67,7 @@ canvas_create_offscreen_from_png(
 
 void
 canvas_set_destroy_callback(
-  void (*callback)(canvas_t *));
+  void (*callback_function)(canvas_t *));
 
 
 

--- a/src/implem/gradient.c
+++ b/src/implem/gradient.c
@@ -280,9 +280,9 @@ static void (*_gradient_destroy_callback)(gradient_t *) = NULL;
 
 void
 gradient_set_destroy_callback(
-  void (*callback)(gradient_t *))
+  void (*callback_function)(gradient_t *))
 {
-  _gradient_destroy_callback = callback;
+  _gradient_destroy_callback = callback_function;
 }
 
 static void

--- a/src/implem/gradient.h
+++ b/src/implem/gradient.h
@@ -58,6 +58,6 @@ gradient_evaluate_pos(
 
 void
 gradient_set_destroy_callback(
-  void (*callback)(gradient_t *));
+  void (*callback_function)(gradient_t *));
 
 #endif /* __GRADIENT_H */

--- a/src/implem/path2d.c
+++ b/src/implem/path2d.c
@@ -397,9 +397,9 @@ static void (*_path2d_destroy_callback)(path2d_t *) = NULL;
 
 void
 path2d_set_destroy_callback(
-  void (*callback)(path2d_t *))
+  void (*callback_function)(path2d_t *))
 {
-  _path2d_destroy_callback = callback;
+  _path2d_destroy_callback = callback_function;
 }
 
 static void

--- a/src/implem/path2d.h
+++ b/src/implem/path2d.h
@@ -120,6 +120,6 @@ path2d_get_path(
 
 void
 path2d_set_destroy_callback(
-  void (*callback)(path2d_t *));
+  void (*callback_function)(path2d_t *));
 
 #endif /* __PATH2D_H */

--- a/src/implem/pattern.h
+++ b/src/implem/pattern.h
@@ -40,6 +40,6 @@ pattern_evaluate_pos(
 
 void
 pattern_set_destroy_callback(
-  void (*callback)(pattern_t *));
+  void (*callback_function)(pattern_t *));
 
 #endif /* __PATTERN_H */


### PR DESCRIPTION
The C function `callback` has been deprecated in 4.14, and has been replaced by `caml_callback`, which exists at least since 4.02.