### PR TITLE
Various improvements on JS backend 

### DIFF
--- a/src/ocamlCanvas.ml
+++ b/src/ocamlCanvas.ml
@@ -542,7 +542,7 @@ module V1 = struct
     external createOnscreen :
       ?autocommit:bool -> ?decorated:bool -> ?resizeable:bool ->
       ?minimize:bool -> ?maximize:bool -> ?close:bool -> ?title:string ->
-      ?pos:(int * int) -> size:(int * int) -> unit -> t
+      ?target:string -> ?pos:(int * int) -> size:(int * int) -> unit -> t
       = "ml_canvas_create_onscreen" "ml_canvas_create_onscreen_n"
 
     external createOffscreen : size:(int * int) -> unit -> t

--- a/src/ocamlCanvas.mli
+++ b/src/ocamlCanvas.mli
@@ -766,9 +766,9 @@ module V1 : sig
     val createOnscreen :
       ?autocommit:bool -> ?decorated:bool -> ?resizeable:bool ->
       ?minimize:bool -> ?maximize:bool -> ?close:bool -> ?title:string ->
-      ?pos:(int * int) -> size:(int * int) -> unit -> t
+      ?target:string -> ?pos:(int * int) -> size:(int * int) -> unit -> t
     (** [createOnscreen ?autocommit ?decorated ?resizeable ?minimize
-        ?maximize ?close ?title ?pos ~size ()] creates a windowed
+        ?maximize ?close ?title ?target ?pos ~size()] creates a windowed
         canvas of size [size]. The window title and position can be
         specified using the optional arguments [title] and [pos].
         The window decorations, which are active by default, can
@@ -777,6 +777,9 @@ module V1 : sig
         The [decorated] argument has a higher priority: if set to false,
         all other decoration arguments will be ignored (considered to be
         false), and all decorations will be removed from the window.
+        The [target] option is relevant only for the Javascript backend.
+        It indicates the element id in which the canvas should be placed,
+        default to the html body.
         The [autocommit] option, which is active by default, indicates whether
         the canvas should be automatically presented after each frame event.
         See {!Canvas.commit} for more info on [autocommit].

--- a/src/stubs/ml_canvas.c
+++ b/src/stubs/ml_canvas.c
@@ -673,12 +673,14 @@ ml_canvas_create_onscreen_n(
   value mlMaximize,   /* bool, optional, default = true */
   value mlClose,      /* bool, optional, default = true */
   value mlTitle,      /* string, optional, default = "" */
+  value mlTarget,     /* string, optional */
   value mlPos,        /* (int * int), optional */
   value mlSize,       /* (int * int), non-optional */
   value mlUnit)
 {
   CAMLparam5(mlAutocommit, mlDecorated, mlResizeable, mlMinimize, mlMaximize);
-  CAMLxparam5(mlClose, mlTitle, mlPos, mlSize, mlUnit);
+  CAMLxparam5(mlClose, mlTitle, mlTarget, mlPos, mlSize);
+  CAMLxparam1(mlUnit);
   CAMLlocal1(mlCanvas);
   _ml_canvas_ensure_initialized();
   int32_t width = Int31_val_clip(Field(mlSize, 0));
@@ -708,7 +710,7 @@ ml_canvas_create_onscreen_n(
   CAMLreturn(mlCanvas);
 }
 
-BYTECODE_STUB_10(ml_canvas_create_onscreen)
+BYTECODE_STUB_11(ml_canvas_create_onscreen)
 
 CAMLprim value
 ml_canvas_create_offscreen(

--- a/src/stubs/ml_canvas.js
+++ b/src/stubs/ml_canvas.js
@@ -178,7 +178,7 @@ function _move_handler(e) {
 //Requires: _ml_canvas_process_event, EVENT_TAG
 //Requires: caml_int64_of_float
 function _resize_handler(entries) {
-  entries.forEach(e => {
+  entries.forEach(function (e) {
     var evt = [EVENT_TAG.CANVAS_RESIZED,
                [0, e.target.canvas,
                 caml_int64_of_float(e.timeStamp * 1000.0),

--- a/src/stubs/ml_canvas.js
+++ b/src/stubs/ml_canvas.js
@@ -1589,10 +1589,10 @@ function ml_canvas_init() {
   if (_ml_canvas_initialized === true) {
     return 0;
   }
-  document.onkeydown = _key_down_handler;
-  document.onkeyup = _key_up_handler;
-  document.onmouseup = _up_handler;
-  document.onmousemove = _move_handler;
+  document.addEventListener("keydown", _key_down_handler, {passive: true});
+  document.addEventListener("keyup", _key_up_handler, {passive: true});
+  document.addEventListener("mouseup", _up_handler, {passive: true});
+  document.addEventListener("mousemove", _move_handler, {passive: true});
   window.requestAnimationFrame(_frame_handler);
   _ml_canvas_initialized = true;
   return 0;

--- a/src/stubs/ml_canvas.js
+++ b/src/stubs/ml_canvas.js
@@ -728,9 +728,7 @@ function ml_canvas_create_onscreen(autocommit, decorated, resizeable, minimize,
     _resize.observe(surface);
   }
 
-  // willReadFrequently needed to avoid warning on getImageData
-  var ctxt = surface.getContext("2d", {willReadFrequently: true});
-  ctxt.will
+  var ctxt = surface.getContext("2d");
   ctxt.globalAlpha = 1.0;
   ctxt.lineWidth = 1.0;
   ctxt.fillStyle = "white";

--- a/src/stubs/ml_canvas.js
+++ b/src/stubs/ml_canvas.js
@@ -112,7 +112,7 @@ function _header_down_handler(e) {
     _move.target = e.target.canvas.frame;
     _move.prev_x = e.pageX;
     _move.prev_y = e.pageY;
-    document.body.insertBefore(_move.target, null);
+    e.target.canvas.target.insertBefore(_move.target, null);
   }
   return false;
 }
@@ -123,7 +123,7 @@ function _header_down_handler(e) {
 function _surface_down_handler(e) {
   if (e.target !== null) {
     _focus = e.target.canvas;
-    document.body.insertBefore(e.target.canvas.frame, null);
+    e.target.canvas.target.insertBefore(e.target.canvas.frame, null);
     var evt = [EVENT_TAG.BUTTON_ACTION,
                [0, e.target.canvas,
                 caml_int64_of_float(e.timeStamp * 1000.0),
@@ -634,8 +634,8 @@ function _ml_canvas_decorate(header, minimize,
 //Requires: _ml_canvas_ensure_initialized, _ml_canvas_valid_canvas_size, _resize, _next_id, _header_down_handler
 //Requires: _surface_down_handler, _up_handler, _move_handler, _ml_canvas_decorate, Optional_bool_val, Optional_val
 //Requires: caml_invalid_argument
-function ml_canvas_create_onscreen(autocmmit, decorated, resizeable, minimize,
-                                   maximize, close, title, pos, size) {
+function ml_canvas_create_onscreen(autocommit, decorated, resizeable, minimize,
+                                   maximize, close, title, target, pos, size) {
 
   _ml_canvas_ensure_initialized();
 
@@ -656,11 +656,17 @@ function ml_canvas_create_onscreen(autocmmit, decorated, resizeable, minimize,
   var maximize = Optional_bool_val(maximize, true);
   var close = Optional_bool_val(close, true);
   var title = Optional_val(title, null);
+  var target = Optional_val(target, null);
+  target = document.getElementById(target);
+  if(target == null) {
+    target = document.body;
+  }
 
   var id = ++_next_id;
 
   var canvas = {
     name: title,
+    target: target,
     frame: null,
     header: null,
     surface: null,
@@ -691,7 +697,7 @@ function ml_canvas_create_onscreen(autocmmit, decorated, resizeable, minimize,
   frame.oncontextmenu = function() { return false; }
   frame.canvas = canvas;
   canvas.frame = frame;
-  document.body.appendChild(frame);
+  target.appendChild(frame);
 
   var header = null;
   if (decorated === true) {

--- a/src/stubs/ml_canvas.js
+++ b/src/stubs/ml_canvas.js
@@ -55,6 +55,13 @@ var _move = {
 //Requires: _resize_handler
 var _resize = new window.ResizeObserver(_resize_handler);
 
+//Provides: _event_canvas_scale
+function _event_canvas_scale(e) {
+    return { scaleX : e.target.canvas.width / e.target.clientWidth,
+             scaleY : e.target.canvas.height / e.target.clientHeight
+           }
+}
+
 //Provides: _make_key_event
 //Requires: _focus, keyname_to_keycode, Val_key_code, Val_key_state, EVENT_TAG
 //Requires: caml_int64_of_float
@@ -118,38 +125,40 @@ function _header_down_handler(e) {
 }
 
 //Provides: _surface_down_handler
-//Requires: _focus, _ml_canvas_process_event, EVENT_TAG
+//Requires: _focus, _ml_canvas_process_event, _event_canvas_scale, EVENT_TAG
 //Requires: caml_int64_of_float
 function _surface_down_handler(e) {
   if (e.target !== null) {
     _focus = e.target.canvas;
     e.target.canvas.target.insertBefore(e.target.canvas.frame, null);
+    var s = _event_canvas_scale(e);
     var evt = [EVENT_TAG.BUTTON_ACTION,
                [0, e.target.canvas,
                 caml_int64_of_float(e.timeStamp * 1000.0),
-                [0, e.offsetX, e.offsetY], e.button + 1, 1]];
+                [0, e.offsetX*s.scaleX, e.offsetY*s.scaleY], e.button + 1, 1]];
     _ml_canvas_process_event(evt);
   }
   return false;
 }
 
 //Provides: _up_handler
-//Requires: _move, _ml_canvas_process_event, EVENT_TAG
+//Requires: _move, _ml_canvas_process_event, _event_canvas_scale, EVENT_TAG
 //Requires: caml_int64_of_float
 function _up_handler(e) {
   _move.moving = false;
   if (e.target.canvas !== undefined) {
+    var s = _event_canvas_scale(e);
     var evt = [EVENT_TAG.BUTTON_ACTION,
                [0, e.target.canvas,
                 caml_int64_of_float(e.timeStamp * 1000.0),
-                [0, e.offsetX, e.offsetY], e.button + 1, 0]];
+                [0, e.offsetX*s.scaleX, e.offsetY*s.scaleY], e.button + 1, 0]];
     _ml_canvas_process_event(evt);
   }
   return false; // = prevent default behavior
 }
 
 //Provides: _move_handler
-//Requires: _move, _ml_canvas_process_event, EVENT_TAG
+//Requires: _move, _ml_canvas_process_event, _event_canvas_scale, EVENT_TAG
 //Requires: caml_int64_of_float
 function _move_handler(e) {
   if (_move.moving) {
@@ -165,10 +174,11 @@ function _move_handler(e) {
     _move.target.style.left = canvas.x + "px";
     _move.target.style.top = canvas.y + "px";
   } else if (e.target.canvas !== undefined) {
+    var s = _event_canvas_scale(e);
     var evt = [EVENT_TAG.MOUSE_MOVE,
                [0, e.target.canvas,
                 caml_int64_of_float(e.timeStamp * 1000.0),
-                [0, e.offsetX, e.offsetY]]];
+                [0, e.offsetX*s.scaleX, e.offsetY*s.scaleY]]];
     _ml_canvas_process_event(evt);
   }
   return false;


### PR DESCRIPTION
Main changes are:
- Responsive resizing of the canvas along page layout (using `resizeable` option).
- Option to specify target element id of canvases to be nested in the page at users will, instead of top of `body`.
- Tweak to allow usual browser input reaction to go through, in particular keyboard shortcuts.

Also, disabled decorations entirely in this backend, as it doesn't fit browser/webapp UX design.

A note on restoring shortcuts : The issue was related to [event default action](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners) unable to trigger unless eventListeners were set to `passive`. This indicates that OcamlCanvas eventListener are not terminating properly, but I was unable to understand if that was actually the case and why. I suspect it has something to do with the way `Backend.run` works but I can't be sure.
Either way, the proposed solution is not ideal as it will hinder the user to actually prevent default action when needed. 