### PR TITLE
Add examples to the doc pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ doc-common: build
 	mkdir -p _build/docs
 	rsync -auv docs/. _build/docs/.
 
+doc-examples: build
+	mkdir -p _build/docs/examples
+	cp _build/default/examples/*.js _build/docs/examples/.
+	cp _build/default/examples/*.html _build/docs/examples/.
+
 sphinx: doc-common
 	sphinx-build sphinx ${SPHINX_TARGET}
 
@@ -34,7 +39,7 @@ odoc: doc-common
 	opam exec -- dune build @doc
 	rsync -auv --delete _build/default/_doc/_html/. ${ODOC_TARGET}
 
-doc: doc-common odoc sphinx
+doc: doc-common doc-examples odoc sphinx
 
 view:
 	xdg-open file://$$(pwd)/_build/docs/index.html

--- a/docs/index.html
+++ b/docs/index.html
@@ -25,6 +25,7 @@
           <li><a href="https://github.com/ocamlpro/ocaml-canvas">Project on Github</a></li>
           <li><a href="https://ocamlpro.github.io/ocaml-canvas/sphinx">General Documentation</a></li>
           <li><a href="https://ocamlpro.github.io/ocaml-canvas/doc">API Documentation</a></li>
+          <li><a href="examples/index.html">Examples</a></li>
           <li><a href="https://github.com/ocamlpro/ocaml-canvas/issues">Bug reports</a></li>
         </ul>
         <h3>Authors:</h3>

--- a/src/stubs/ml_canvas.js
+++ b/src/stubs/ml_canvas.js
@@ -202,11 +202,7 @@ function _ml_canvas_image_of_png_file(filename) {
   img.loading = 'eager';
   img.decoding = 'sync';
   img.src = 'data:image/png;base64,' + data;
-  var dimg = img.decode();
-  dimg.catch(function (err) {
-    caml_raise_with_string(caml_named_value("Read_png_failed"), err.message);
-  });
-  return [dimg, img];
+  return [img.decode(), img];
 }
 
 //Provides: _ml_canvas_ba_of_img
@@ -270,8 +266,6 @@ function ml_canvas_image_data_create_from_png(filename, onload) {
   img[0].then(function (__img) {
     var ba = _ml_canvas_ba_of_img(img[1]);
     onload(ba);
-    return 0;
-  }, function (__err) {
     return 0;
   });
   return 0;
@@ -416,8 +410,6 @@ function ml_canvas_image_data_import_png(data, pos, filename, onload) {
       dta[i] = sta[i];
     }
     onload(data);
-    return 0;
-  }, function (__err) {
     return 0;
   });
   return 0;
@@ -814,8 +806,6 @@ function ml_canvas_create_offscreen_from_png(filename, onload) {
     }
     canvas.ctxt.drawImage(img[1], 0, 0);
     onload(canvas);
-    return 0;
-  }, function (__err) {
     return 0;
   });
   return 0;
@@ -1514,8 +1504,6 @@ function ml_canvas_import_png(canvas, pos, filename, onload) {
     canvas.ctxt.drawImage(img[1], pos[1], pos[2]);
     // image, sx, sy, sWitdh, sHeight, dx, dy, dWidth, dHeight
     onload(canvas);
-    return 0;
-  }, function (__err) {
     return 0;
   });
   return 0;

--- a/src/stubs/ml_canvas.js
+++ b/src/stubs/ml_canvas.js
@@ -189,19 +189,24 @@ function _frame_handler(timestamp) {
 /* Image Data (aka Pixmaps) */
 
 //Provides: _ml_canvas_image_of_png_file
-//Requires: caml_read_file_content
+//Requires: caml_read_file_content, caml_raise_with_string, caml_named_value
 function _ml_canvas_image_of_png_file(filename) {
   var file = caml_read_file_content(filename);
   if (file === null) {
     return null;
   }
   var fc = caml_read_file_content(filename);
-  var data = window.btoa(fc.toUft16 === undefined ? fc.c : fc);
+  // Test for mlBytes or JS-string
+  var data = window.btoa(fc.c === undefined ? fc : fc.c);
   var img = new window.Image();
   img.loading = 'eager';
   img.decoding = 'sync';
   img.src = 'data:image/png;base64,' + data;
-  return [img.decode(), img];
+  var dimg = img.decode();
+  dimg.catch(function (err) {
+    caml_raise_with_string(caml_named_value("Read_png_failed"), err.message);
+  });
+  return [dimg, img];
 }
 
 //Provides: _ml_canvas_ba_of_img


### PR DESCRIPTION
This should make JS version of examples accessible to the github page after deployment. 